### PR TITLE
fix: disable managed cert in serverless_negs module

### DIFF
--- a/terraform/load_balancing.tf
+++ b/terraform/load_balancing.tf
@@ -11,20 +11,26 @@ resource "google_compute_region_network_endpoint_group" "gateway" {
   }
 }
 
+# Create Cert manually
+# https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list
+data "google_compute_ssl_certificate" "default" {
+  name = var.cert
+}
+
 module "gateway_lb" {
   source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version = "~> 5.0"
 
-  project                         = var.project
-  name                            = var.name
-  address                         = google_compute_global_address.gateway.self_link
-  create_address                  = false
-  cdn                             = false
-  ssl                             = true
-  use_ssl_certificates            = false
-  managed_ssl_certificate_domains = var.domains
-  https_redirect                  = true
-  quic                            = true
+  project              = var.project
+  name                 = var.name
+  address              = google_compute_global_address.gateway.self_link
+  create_address       = false
+  cdn                  = false
+  ssl                  = true
+  use_ssl_certificates = true
+  ssl_certificates     = [data.google_compute_ssl_certificate.default.self_link]
+  https_redirect       = true
+  quic                 = true
 
   backends = {
     default = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,8 +51,8 @@ variable "oauth_client_secret" {
   type = string
 }
 
-variable "domains" {
-  type = list(string)
+variable "cert" {
+  type = string
 }
 
 // application environments


### PR DESCRIPTION
google_compute_managed_ssl_certificate を使う場合、ドメイン名を変更する際のオペレーションが困難なため、証明書は手動管理として data resource で参照するよう変更します。

> ⚠ Warning:
This resource should be used with extreme caution! Provisioning an SSL certificate is complex. Ensure that you understand the lifecycle of a certificate before attempting complex tasks like cert rotation automatically. This resource will "return" as soon as the certificate object is created, but post-creation the certificate object will go through a "provisioning" process. The provisioning process can complete only when the domain name for which the certificate is created points to a target pool which, itself, points at the certificate. Depending on your DNS provider, this may take some time, and migrating from self-managed certificates to Google-managed certificates may entail some downtime while the certificate provisions.
cf. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate

## References
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_ssl_certificate
- https://registry.terraform.io/modules/GoogleCloudPlatform/lb-http/google/latest/submodules/serverless_negs